### PR TITLE
CON-2774: Refactored the search selector

### DIFF
--- a/selectors/search.js
+++ b/selectors/search.js
@@ -6,8 +6,10 @@
  */
 
 import { createSelector } from 'reselect';
-import { getSearchPhrase } from '@shopgate/pwa-common-commerce/search/selectors/index';
-import { getSortOrder } from '@shopgate/pwa-common/selectors/history';
+import {
+  getSortOrder,
+  getSearchPhrase,
+} from '@shopgate/pwa-common/selectors/history';
 import { generateResultHash } from '@shopgate/pwa-common/helpers/redux';
 
 /**
@@ -27,7 +29,10 @@ const resultCountSelector = createSelector(
   getSortOrder,
   resultsSelector,
   (searchPhrase, sort, results) => {
-    const hash = searchPhrase && generateResultHash({ sort, searchPhrase });
+    const hash = searchPhrase && generateResultHash({
+      sort,
+      searchPhrase,
+    });
 
     if (!hash || !results[hash]) {
       return null;


### PR DESCRIPTION
- it now uses the getSearchPhrase history selector from pwa-common instead of the navigator selector from pwa-common-commerce